### PR TITLE
Map external port 27000 to internal port 8081

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       image: mongo-express
       restart: always
       ports:
-        - 27000:27000
+        - 27000:8081
       environment:
         ME_CONFIG_MONGODB_ADMINUSERNAME: root
         ME_CONFIG_MONGODB_ADMINPASSWORD: example


### PR DESCRIPTION
mongo-express listens on port 8081 not port 27000